### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cargo install cargo-sort
 ## pre-commit
 
 If you use [pre-commit](https://pre-commit.com/) in your project, you can add cargo-sort as hook by
-adding the following entry to your `.pre-commit0-config.yaml` configuration:
+adding the following entry to your `.pre-commit-config.yaml` configuration:
 
 ```yaml
 repos:


### PR DESCRIPTION
I found a little typo in `README.md`. There is `0` inside the filename which is probably a typo.

https://github.com/DevinR528/cargo-sort/blob/8a5d3fdea9b11b9bd6caab2cc08e2cb96c9e9cbf/README.md?plain=1#L76

## Changes

change `.pre-commit0-config.yaml` to `.pre-commit-config.yaml`.